### PR TITLE
Change package name to @hashgraph scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The SDK does not impose any particular way of how the DID or verifiable credenti
 
 ## Usage
 ```
-npm install --save did-sdk-js
+npm install --save @hashgraph/did-sdk-js
 ```
 
 ## Example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "did-sdk-js",
-  "version": "0.0.1",
+  "name": "@hashgraph/did-sdk-js",
+  "version": "0.1.0",
   "description": "Support for the Hedera Hashgraph DID Method and Verifiable Credentials on the Hedera JavaScript/TypeScript SDK",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/hashgraph/did-sdk-js.git"
   },
-  "author": "",
+  "author": "Hedera Hashgraph, LLC",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/hashgraph/did-sdk-js/issues"


### PR DESCRIPTION
**Description**:
- Add a Dependabot configuration for automated dependency upgrades
- Change package name to be part of the `@hashgraph` scope
- Change version number to `0.1.0`

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
