### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# This workflow will run tests using node and then publish a package to GitHub Packages when a tag is created.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags: [ 'v*' ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
-    tags: [ v* ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/did-sdk-js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Support for the Hedera Hashgraph DID Method and Verifiable Credentials on the Hedera JavaScript/TypeScript SDK",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
**Description**:
* Fix the release workflow
* Fix tests running both on tag and release
* Bump version to v0.1.1

**Related issue(s)**:

**Notes for reviewer**:
GitHub release with type `created` event didn't trigger anything. Investigation reveals a `published` type might trigger it but it's probably better to just trigger off of tags.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
