### PR TITLE
chore: Update publishing workflow for npmjs packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Test Version String (No release to Maven Central)
         required: true
+      dry-run-enabled:
+        description: 'Enable dry run for publishing (does not publish to npmjs)'
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -20,6 +25,7 @@ defaults:
 
 permissions:
   contents: read
+  id-token: write
   packages: write
 
 jobs:
@@ -52,29 +58,80 @@ jobs:
           OPERATOR_ID: ${{ secrets.OPERATOR_ID }}
           OPERATOR_KEY: ${{ secrets.OPERATOR_KEY }}
 
-  publish:
+  build-npm-package:
     needs: build
     runs-on: decentralized-identity-linux-medium
+    outputs:
+      npm-artifact-name: ${{ steps.set-publish-data.outputs.artifact-name }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@ed4a98646fe0235e6ecf3af5414b355d2abe3bf3 # v1.0.3
         with:
-          egress-policy: audit
+          checkout: 'true'
+          checkout-ref: '${{ github.ref }}'
+          checkout-fetch-depth: '1'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
+          setup-node: 'true'
+          node-version: '14'
 
-      - name: Checkout Code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup JQ
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
         with:
-          cache: 'npm'
-          node-version: 14
-          registry-url: https://registry.npmjs.org/
+          version: 1.7
 
       - name: Run CI
         run: npm ci
 
-      - name: Publish build
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN }}
+      - name: Set Publish Data
+        id: set-publish-data
+        run: |
+          VERSION=$(jq -r '.version' './package.json')
+          NPM_PACKAGE_NAME="hashgraph-did-sdk-js-${VERSION}.tgz"
+          echo "artifact-name=${NPM_PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build npm project
+        id: npm-pack
+        run: npm pack
+
+      - name: Upload DID-SDK-JS Package Artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: npm-package
+          path: ./${{ steps.set-publish-data.outputs.artifact-name }}
+          if-no-files-found: error
+
+  publish-npm-package:
+    runs-on: ubuntu-latest
+    needs:
+      - build-npm-package
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@ed4a98646fe0235e6ecf3af5414b355d2abe3bf3 # v1.0.3
+        with:
+          checkout: 'true'
+          checkout-ref: '${{ github.ref }}'
+          checkout-fetch-depth: '1'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
+          setup-node: 'true'
+          node-version: '20.x'
+          node-registry: 'https://registry.npmjs.org'
+
+      - name: Install NPM latest
+        run: npm install -g npm@11.7.0
+
+      - name: Download DID SDK JS NPM Package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: npm-package
+
+      - name: Publish NPM Package
+        run: |
+          args="--access=public"
+          if [[ "${{ inputs.dry-run-enabled || 'false' }}" == "true" ]]; then
+            args="${args} --dry-run"
+          fi
+
+          package="${{ needs.build-npm-package.outputs.npm-artifact-name }}"
+          echo "::group::Publishing package: ${package} with args: ${args}"
+          npm publish ${package} ${args}
+          echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           checkout-fetch-depth: '1'
           checkout-token: '${{ secrets.GITHUB_TOKEN }}'
           setup-node: 'true'
-          node-version: '20.x'
+          node-version: '14'
           node-registry: 'https://registry.npmjs.org'
 
       - name: Install NPM latest


### PR DESCRIPTION
## Description

This pull request significantly refactors the npm package build and publish process in the `release.yml` GitHub Actions workflow. The main improvements include splitting the build and publish steps into separate jobs, adding support for dry-run publishing, and modernizing the runner setup for better maintainability and security.

**Build and publish workflow improvements:**

* The npm package build and publish process is now split into two jobs: `build-npm-package` (which builds and uploads the package artifact) and `publish-npm-package` (which downloads and publishes the artifact to npm). This separation improves clarity and reliability of the workflow.
* Added a `dry-run-enabled` input parameter to allow publishing to npm in dry-run mode, making it easier to test the release process without actually publishing the package. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16-R28) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-R137)

**Runner and tooling enhancements:**

* Replaced the `step-security/harden-runner` and `actions/checkout` steps with `pandaswhocode/initialize-github-job`, which consolidates runner preparation, code checkout, and Node.js setup for improved maintainability.
* Added a step to install the latest npm version (`npm@11.7.0`) before publishing, ensuring compatibility with npm registry requirements.
* Added a step to install `jq` for parsing the package version, which is used to set the artifact name dynamically.

**Permissions and security:**

* Updated workflow permissions to include `id-token: write`, which may be required for publishing to certain registries or for future security enhancements.

## Related Issue(s)

Closes #213 